### PR TITLE
configure fixes for gcc-14

### DIFF
--- a/Configure
+++ b/Configure
@@ -76,7 +76,7 @@ done
 CFLAGS="$COPT $CEXTRA"
 
 echo "Checking for libraries"
-echo 'main(){}' > test.c
+echo 'int main(void){ return 0; }' > test.c
 LFLAGS=""
 for lib in -lcurses -lncurses; do
 	if $CC $CFLAGS $LEXTRA test.c $lib > /dev/null 2>&1; then
@@ -91,8 +91,9 @@ done
 
 echo "Checking for on_exit()"
 cat << END > test.c
+#include <stdlib.h>
 void handler(void) {}
-main() { on_exit(handler, (void *)0); }
+int main(void) { on_exit(handler, (void *)0); return 0; }
 END
 if $CC $CFLAGS $LEXTRA test.c > /dev/null 2>&1; then
 	HAS_ON_EXIT=true
@@ -103,7 +104,7 @@ fi
 echo "Checking for sigprocmask()"
 cat << END > test.c
 #include <signal.h>
-main() { sigset_t set; sigprocmask(SIG_BLOCK, &set, &set); }
+int main(void) { sigset_t set; sigprocmask(SIG_BLOCK, &set, &set); return 0; }
 END
 if $CC $CFLAGS $LEXTRA test.c > /dev/null 2>&1; then
 	HAS_SIGPROCMASK=true
@@ -114,7 +115,7 @@ fi
 echo "Checking for getopt.h"
 cat << END > test.c
 #include <getopt.h>
-main(){}
+int main(void){ return 0; }
 END
 
 if $CC $CFLAGS $LEXTRA test.c > /dev/null 2>&1; then
@@ -126,7 +127,7 @@ fi
 echo "Checking for memory.h"
 cat << END > test.c
 #include <memory.h>
-main(){}
+int main(void){ return 0; }
 END
 
 if $CC $CFLAGS $LEXTRA test.c > /dev/null 2>&1; then


### PR DESCRIPTION
fixes build with `gcc-14`. the `on_exit` check fails due to 

> test.c: In function ‘main’:
test.c:3:26: error: passing argument 1 of ‘on_exit’ from incompatible pointer type [-Wincompatible-pointer-types]
    3 | int main(void) { on_exit(handler, (void *)0); return 0; }
      |                          ^~~~~~~
      |                          |
      |                          void (*)(void)
In file included from test.c:1:
/usr/include/stdlib.h:749:28: note: expected ‘void (*)(int, void *)’ but argument is of type ‘void (*)(void)’
  749 | extern int on_exit (void (*__func) (int __status, void *__arg), void *__arg)


but given that `util.c` will fallback to `atexit` that seems fine.